### PR TITLE
Change install.sh: download only image, not entire repo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,14 @@
 #!/bin/bash
 
-echo 'Cloning repo'
-git clone https://github.com/egold/better-xcode-ibeam-cursor.git
-cd better-xcode-ibeam-cursor
+echo 'Downloading new image'
+curl -o /tmp/DVTIbeamCursor.tiff https://raw.githubusercontent.com/egold/better-xcode-ibeam-cursor/master/DVTIbeamCursor.tiff
 
 echo 'Backing up the original cursor that ships with xcode to ./backup-DVTIbeamCursor.tiff'
 cp /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff ./backup-DVTIbeamCursor.tiff
 echo 'Copying the improved ibeam cursor to the correct location'
-sudo cp DVTIbeamCursor.tiff /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff
+sudo cp /tmp/DVTIbeamCursor.tiff /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff
 
-echo 'Removing repo'
-cd ../
-rm -rf better-xcode-ibeam-cursor
+echo 'Removing downloaded image'
+rm -f /tmp/DVTIbeamCursor.tiff
 
 echo 'Done - restart Xcode and have fun!'


### PR DESCRIPTION
install.sh no longer relies on git, and relies on curl instead
This also no longer deletes the backup cursor tiff which was placed in
the repo directory, which was then cleaned up after instal.sh ran.
