### PR TITLE
install.sh improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+XCODE_RESOURCE_PATH=/Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources
+
 echo 'Downloading new image'
 curl -o /tmp/DVTIbeamCursor.tiff https://raw.githubusercontent.com/egold/better-xcode-ibeam-cursor/master/DVTIbeamCursor.tiff
 
 echo 'Backing up the original cursor that ships with xcode to ./backup-DVTIbeamCursor.tiff'
-cp /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff ./backup-DVTIbeamCursor.tiff
+cp $XCODE_RESOURCE_PATH/DVTIbeamCursor.tiff $XCODE_RESOURCE_PATH/backup-DVTIbeamCursor.tiff
+
 echo 'Copying the improved ibeam cursor to the correct location'
-sudo cp /tmp/DVTIbeamCursor.tiff /Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Resources/DVTIbeamCursor.tiff
+sudo cp /tmp/DVTIbeamCursor.tiff $XCODE_RESOURCE_PATH/DVTIbeamCursor.tiff
 
 echo 'Removing downloaded image'
 rm -f /tmp/DVTIbeamCursor.tiff


### PR DESCRIPTION
After I ran the install script it was weird to find a backup copy of the cursor in my current working directory. Modified the script so it's backed up in the same directory.

Changes:

* move resource path into a variable
* store backup in original folder, not where script is run